### PR TITLE
Allow files to be ignored even if they are added to files to check.

### DIFF
--- a/phpcs-pre-commit/pre-commit
+++ b/phpcs-pre-commit/pre-commit
@@ -53,7 +53,11 @@ for FILE in $FILES
 do
     echo "$FILE" | egrep -q "$PHPCS_FILE_PATTERN"
     RETVAL=$?
-    if [ "$RETVAL" -eq "0" ]
+    echo "$FILE" | egrep -q "$PHPCS_IGNORE"
+    RETVAL_IGNORE=$?
+    # File is found in file pattern and not found in ignore pattern.
+    # Then add it to files to check.
+    if [ "$RETVAL" -eq "0" ] && [ "$RETVAL_IGNORE" -eq "1" ]
     then
         FILES_TO_CHECK="$FILES_TO_CHECK $FILE"
     fi
@@ -61,13 +65,6 @@ done
 
 if [ "$FILES_TO_CHECK" == "" ]; then
     exit 0
-fi
-
-# execute the code sniffer
-if [ "$PHPCS_IGNORE" != "" ]; then
-    IGNORE="--ignore=$PHPCS_IGNORE"
-else
-    IGNORE=""
 fi
 
 # Copy contents of staged version of files to temporary staging area
@@ -85,7 +82,7 @@ do
   STAGED_FILES="$STAGED_FILES $TMP_STAGING/$FILE"
 done
 
-OUTPUT=$($PHPCS_BIN -s --standard=$PHPCS_CODING_STANDARD $IGNORE $STAGED_FILES)
+OUTPUT=$($PHPCS_BIN -s --standard=$PHPCS_CODING_STANDARD $STAGED_FILES)
 RETVAL=$?
 
 # delete temporary copy of staging area


### PR DESCRIPTION
The ignore pattern is applied in the files to check loop, since it was
not possible to ignore a file that was already in the files to check
array.

For instance, I want all *.php files to be checked, except files with
*.ini.append.php extension.

This does not work, but it should:

phpcs -s --standard PEAR ./test.ini.append.php --ignore '.(ini.append.php)$'

Here is my config

PHPCS_IGNORE=".(ini.append.php)$"
PHPCS_FILE_PATTERN=".(php|phtml)$"
