### PR TITLE
Pre-commit hook should be executable

### DIFF
--- a/phpcs-pre-commit/README
+++ b/phpcs-pre-commit/README
@@ -22,4 +22,5 @@ USAGE
  * OR: add the script to your pre-commit "chain" (you probably know what to do then)
  * Put the Config file "config" into the same dir as the "pre-commit" script and
    edit it to your requirements
+ * Ensure that the script is executable. 
 


### PR DESCRIPTION
Added a section informing the user that the file needs to be executable in order for the pre-commit hook to work properly.
